### PR TITLE
Adding missing copyright, spaces to tabs in .go files

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package main
 
 import (
@@ -56,8 +57,8 @@ func main() {
 		}
 	}
 
-    //TODO: Build out the partner cert pool if need be.
-    // certpoo
+	//TODO: Build out the partner cert pool if need be.
+	// certpoo
 
 	if opts.Profile != "" {
 		log.Printf("Creating profile %s...\n", opts.Profile)

--- a/src/mozilla.org/util/aws.go
+++ b/src/mozilla.org/util/aws.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package util
 
 import (

--- a/src/mozilla.org/wmf/handlers.go
+++ b/src/mozilla.org/wmf/handlers.go
@@ -163,19 +163,19 @@ func (self *Handler) updatePage(devId string, args map[string]interface{}, logPo
 			location.Time = int64(arg.(float64))
 		case "ha":
 			locked = isTrue(arg)
-            location.Lockable = !locked
+			location.Lockable = !locked
 			if err = self.store.SetDeviceLockable(devId, !locked); err != nil {
 				return err
 			}
 		}
 	}
-    if logPosition {
-    	if err = self.store.SetDeviceLocation(devId, location); err != nil {
-	    	return err
-    	}
-	    // because go sql locking.
-    	self.store.GcPosition(devId)
-    }
+	if logPosition {
+		if err = self.store.SetDeviceLocation(devId, location); err != nil {
+			return err
+		}
+		// because go sql locking.
+		self.store.GcPosition(devId)
+	}
 	if client, ok := Clients[devId]; ok {
 		js, _ := json.Marshal(location)
 		client.Write(js)
@@ -272,7 +272,7 @@ func (self *Handler) Register(resp http.ResponseWriter, req *http.Request) {
 		} else {
 			pushUrl = buffer["pushurl"].(string)
 		}
-        //ALWAYS generate a new secret on registration!
+		//ALWAYS generate a new secret on registration!
 		secret = GenNonce(16)
 		if _, ok = buffer["deviceid"]; !ok {
 			deviceid, err = util.GenUUID4()
@@ -447,11 +447,11 @@ func (self *Handler) Cmd(resp http.ResponseWriter, req *http.Request) {
 			switch c {
 			case "l", "r", "m", "e":
 				err = self.store.Touch(deviceId)
-                self.updatePage(deviceId, args.(map[string]interface{}), false)
-            case "h":
-                argl := make(reply_t)
-                argl[string(cmd)] = isTrue(args)
-                self.updatePage(deviceId, argl, false)
+				self.updatePage(deviceId, args.(map[string]interface{}), false)
+			case "h":
+				argl := make(reply_t)
+				argl[string(cmd)] = isTrue(args)
+				self.updatePage(deviceId, argl, false)
 			case "t":
 				// track
 				err = self.updatePage(deviceId, args.(map[string]interface{}), true)
@@ -505,7 +505,7 @@ func (self *Handler) Queue(resp http.ResponseWriter, req *http.Request) {
 	var err error
 	var lbody int
 
-    rep := make(reply_t)
+	rep := make(reply_t)
 
 	self.logCat = "handler:Queue"
 	resp.Header().Set("Content-Type", "application/json")
@@ -590,8 +590,8 @@ func (self *Handler) Queue(resp http.ResponseWriter, req *http.Request) {
 				self.logger.Warn(self.logCat, "Agent does not accept command",
 					util.Fields{"unacceptable": c,
 						"acceptable": devRec.Accepts})
-                rep["error"] = 422
-                rep["cmd"] = cmd
+				rep["error"] = 422
+				rep["cmd"] = cmd
 				continue
 			}
 			rargs := args.(map[string]interface{})
@@ -668,7 +668,7 @@ func (self *Handler) Queue(resp http.ResponseWriter, req *http.Request) {
 			}
 		}
 	}
-    repl,_ := json.Marshal(rep)
+	repl,_ := json.Marshal(rep)
 	resp.Write(repl)
 }
 

--- a/src/mozilla.org/wmf/push.go
+++ b/src/mozilla.org/wmf/push.go
@@ -5,39 +5,39 @@
 package wmf
 
 import (
-    "mozilla.org/wmf/storage"
-    "mozilla.org/util"
-    "bytes"
-    "crypto/tls"
-    "fmt"
-    "net/http"
-    "errors"
+	"mozilla.org/wmf/storage"
+	"mozilla.org/util"
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"errors"
 )
 
 func SendPush(devRec *storage.Device, config *util.JsMap) error {
 	// wow, so very tempted to make sure this matches the known push server.
 	bbody := []byte{}
 	body := bytes.NewReader(bbody)
-    fmt.Printf("### sending to %s\n", devRec.PushUrl)
-    /* If your server is not trustfully signed, the following will fail.
-       If partners are unable/unwilling to trustfully sign servers, 
-       it is possible to skip validation by using 
-        &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-       however that is not advised as a general policy for damn good reasons.
-    */
-    //TODO: for get the partner's cert pool from the config (based on tld)
-    tr := &http.Transport{
-        TLSClientConfig: &tls.Config{
-            //RootCAs: partnerCertPool,
-            //InsecureSkipVerify: true,
-        },
-    }
+	fmt.Printf("### sending to %s\n", devRec.PushUrl)
+	/* If your server is not trustfully signed, the following will fail.
+		If partners are unable/unwilling to trustfully sign servers, 
+		it is possible to skip validation by using 
+		&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		however that is not advised as a general policy for damn good reasons.
+	*/
+	//TODO: for get the partner's cert pool from the config (based on tld)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			//RootCAs: partnerCertPool,
+			//InsecureSkipVerify: true,
+		},
+	}
 
 	req, err := http.NewRequest("PUT", devRec.PushUrl, body)
 	if err != nil {
 		return err
 	}
-    cli := http.Client{Transport: tr}
+	cli := http.Client{Transport: tr}
 	resp, err := cli.Do(req)
 	if err != nil {
 		return err
@@ -47,5 +47,3 @@ func SendPush(devRec *storage.Device, config *util.JsMap) error {
 	}
 	return nil
 }
-
-

--- a/src/mozilla.org/wmf/storage/storage.go
+++ b/src/mozilla.org/wmf/storage/storage.go
@@ -32,7 +32,7 @@ type Position struct {
 	Longitude float64
 	Altitude  float64
 	Time      int64
-    Lockable  bool
+	Lockable  bool
 }
 
 type Device struct {
@@ -60,45 +60,44 @@ type Users map[string]string
 
 /* Relative:
 
-   table userToDeviceMap:
-       userId   UUID index
-       deviceId UUID
+	table userToDeviceMap:
+		userId   UUID index
+		deviceId UUID
 
-   table pendingCommands:
-       deviceId UUID index
-       time     timeStamp
-       cmd      string
+	table pendingCommands:
+		deviceId UUID index
+		time     timeStamp
+		cmd      string
 
-   table deviceInfo:
-       deviceId       UUID index
-       name           string
-       lockable       boolean
-       loggedin       boolean
-       lastExchange   time
-       hawkSecret     string
-       pushUrl        string
-       pendingCommand string
-       accepts        string
+	table deviceInfo:
+		deviceId       UUID index
+		name           string
+		lockable       boolean
+		loggedin       boolean
+		lastExchange   time
+		hawkSecret     string
+		pushUrl        string
+		pendingCommand string
+		accepts        string
 
-   table position:
-       positionId UUID index
-       deviceId   UUID index
-       expry      interval index
-       time       timeStamp
-       latitude   float
-       longitude  float
-       altitude   float
+	table position:
+		positionId UUID index
+		deviceId   UUID index
+		expry      interval index
+		time       timeStamp
+		latitude   float
+		longitude  float
+		altitude   float
 */
 /* key:
-   deviceId {positions:[{lat:float, lon: float, alt: float, time:int},...],
-             lockable: bool
-             lastExchange: int
-             secret: string
-             pending: string
-            }
+	deviceId {positions:[{lat:float, lon: float, alt: float, time:int},...],
+			 lockable: bool
+			 lastExchange: int
+			 secret: string
+			 pending: string
+			}
 
-   user [deviceId:name,...]
-
+	user [deviceId:name,...]
 */
 // Using Relative for now, because backups.
 
@@ -164,7 +163,7 @@ func (self *Storage) Init() (err error) {
 		"create or replace function update_time() returns trigger as $$ begin new.lastexchange = now(); return new; end; $$ language 'plpgsql';",
 		"drop trigger if exists update_le on deviceinfo;",
 		"create trigger update_le before update on deviceinfo for each row execute procedure update_time();",
-        "set time zone utc;",
+		"set time zone utc;",
 	}
 
 	dbh := self.db
@@ -211,7 +210,7 @@ func (self *Storage) RegisterDevice(userid string, dev Device) (devId string, er
 				dev.Lockable,
 				dev.Accepts,
 				dev.PushUrl,
-                dev.Secret,
+				dev.Secret,
 			); err != nil {
 				self.logger.Error(self.logCat, "Could not update device",
 					util.Fields{"error": err.Error(),
@@ -363,7 +362,7 @@ func (self *Storage) GetPending(devId string) (cmd string, err error) {
 		statement = "delete from pendingCommands where id = $1"
 		dbh.Exec(statement, id)
 	}
-    self.Touch(devId)
+	self.Touch(devId)
 	return cmd, nil
 }
 
@@ -492,23 +491,23 @@ func (self *Storage) Touch(devId string) (err error) {
 }
 
 func (self *Storage) DeleteDevice(devId string) (err error) {
-    dbh := self.db
+	dbh := self.db
 
-    var tables = []string{"pendingcommands", "position", "usertodevice",
-        "deviceinfo"}
+	var tables = []string{"pendingcommands", "position", "usertodevice",
+		"deviceinfo"}
 
-    for t := range tables {
-        // BURN THE WITCH!
-        table := tables[t]
-        _, err = dbh.Exec("delete from $1 where deviceid=$2;", table, devId)
-        if err != nil {
-            self.logger.Error(self.logCat,
-                "Could not nuke data from table",
-                util.Fields{"error": err.Error(),
-                    "device": devId,
-                    "table": table})
-            return err
-        }
-    }
-    return nil
+	for t := range tables {
+		// BURN THE WITCH!
+		table := tables[t]
+		_, err = dbh.Exec("delete from $1 where deviceid=$2;", table, devId)
+		if err != nil {
+			self.logger.Error(self.logCat,
+				"Could not nuke data from table",
+				util.Fields{"error": err.Error(),
+					"device": devId,
+					"table": table})
+			return err
+		}
+	}
+	return nil
 }

--- a/src/mozilla.org/wmf/utils.go
+++ b/src/mozilla.org/wmf/utils.go
@@ -5,15 +5,14 @@
 package wmf
 
 import (
-    "mozilla.org/util"
+	"mozilla.org/util"
 
-    "io"
-    "io/ioutil"
-    "strconv"
-    "net/http"
-    "encoding/json"
-    "strings"
-
+	"io"
+	"io/ioutil"
+	"strconv"
+	"net/http"
+	"encoding/json"
+	"strings"
 )
 
 //filters
@@ -89,5 +88,3 @@ func setSessionInfo(resp http.ResponseWriter, session *sessionInfo) (err error) 
 	}
 	return err
 }
-
-

--- a/src/mozilla.org/wmf/worker.go
+++ b/src/mozilla.org/wmf/worker.go
@@ -9,7 +9,7 @@ import (
 	"mozilla.org/util"
 
 	"io"
-    "strconv"
+	"strconv"
 	"time"
 )
 
@@ -31,10 +31,10 @@ func (self *WWS) sniffer() {
 	)
 
 	defer func() {
-        lived := int64(time.Now().Sub(self.Born).Seconds())
-        self.Logger.Debug("worker",
-            "Closing go routine",
-            util.Fields{"seconds_lived": strconv.FormatInt(lived, 10)})
+		lived := int64(time.Now().Sub(self.Born).Seconds())
+		self.Logger.Debug("worker",
+			"Closing go routine",
+			util.Fields{"seconds_lived": strconv.FormatInt(lived, 10)})
 	}()
 
 	for {
@@ -67,7 +67,7 @@ func (self *WWS) sniffer() {
 func (self *WWS) Run() {
 	self.input = make(chan string)
 	self.quitter = make(chan bool)
-    self.output = make(chan []byte)
+	self.output = make(chan []byte)
 
 	defer func(sock *WWS) {
 		if r := recover(); r != nil {
@@ -95,17 +95,17 @@ func (self *WWS) Run() {
 			self.Quit = true
 			return
 		case input := <-self.input:
-            self.Logger.Debug("worker",
-                "ignoring input",
-                util.Fields{
-                    "input": input[:100],
-                    "len": strconv.FormatInt(int64(len(input)), 10)})
+			self.Logger.Debug("worker",
+				"ignoring input",
+				util.Fields{
+					"input": input[:100],
+					"len": strconv.FormatInt(int64(len(input)), 10)})
 		case output := <-self.output:
-		    _, err := self.Socket.Write(output)
+			_, err := self.Socket.Write(output)
 			if err != nil {
 				self.Logger.Error("worker",
-                "Unhandled error writing to socket",
-                util.Fields{"error": err.Error()})
+					"Unhandled error writing to socket",
+					util.Fields{"error": err.Error()})
 			}
 		}
 	}


### PR DESCRIPTION
a bunch of silly tabs+spaces tweaks, easiest to review using https://github.com/pdehaan/wmf/compare/spaces2tabs?expand=1&w=0
1. Added missing copyright header in [src/mozilla.org/util/aws.go](https://github.com/jrconlin/wmf/blob/master/src/mozilla.org/util/aws.go)
2. Noticed a few files had mixed tabs and spaces, so I converted 4 leading spaces to tabs for consistency (it seemed most files were tab-dominant). I only looked at the .go files, so not sure if we care enough to go through the .html, .js, .py files and also use tabs (or whatever).
