### PR TITLE
fixing a few jshint warnings

### DIFF
--- a/new_static/.jshintrc
+++ b/new_static/.jshintrc
@@ -7,7 +7,6 @@
     "curly": true,
     "eqeqeq": true,
     "immed": true,
-    "indent": 4,
     "latedef": true,
     "newcap": true,
     "noarg": true,

--- a/new_static/Gruntfile.js
+++ b/new_static/Gruntfile.js
@@ -1,9 +1,13 @@
 'use strict';
+
+var path = require('path');
+
 var LIVERELOAD_PORT = 35729;
 var SERVER_PORT = 9000;
 var lrSnippet = require('connect-livereload')({port: LIVERELOAD_PORT});
+
 var mountFolder = function (connect, dir) {
-    return connect.static(require('path').resolve(dir));
+    return connect.static(path.resolve(dir));
 };
 
 // # Globbing
@@ -16,6 +20,7 @@ var mountFolder = function (connect, dir) {
 module.exports = function (grunt) {
     // show elapsed time at the end
     require('time-grunt')(grunt);
+
     // load all grunt tasks
     require('load-grunt-tasks')(grunt);
 
@@ -182,7 +187,7 @@ module.exports = function (grunt) {
                     // http://requirejs.org/docs/errors.html#sourcemapcomments
                     preserveLicenseComments: false,
                     useStrict: true,
-                    wrap: true,
+                    wrap: true
                     //stubModules: ['text', 'stache']
                     //uglify2: {} // https://github.com/mishoo/UglifyJS2
                 }
@@ -271,7 +276,7 @@ module.exports = function (grunt) {
                         '<%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%= yeoman.dist %>/styles/{,*/}*.css',
                         '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
-                        '/styles/fonts/{,*/}*.*',
+                        '/styles/fonts/{,*/}*.*'
                     ]
                 }
             }
@@ -290,7 +295,7 @@ module.exports = function (grunt) {
         }
     });
 
-    grunt.registerTask('server', function () {
+    grunt.registerTask('server', 'The `server` task has been deprecated. Use `grunt serve` to start a server.', function (target) {
         grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.');
         grunt.task.run(['serve:' + target]);
     });

--- a/new_static/app/scripts/lib/modal_manager.js
+++ b/new_static/app/scripts/lib/modal_manager.js
@@ -37,7 +37,7 @@ define([
 
     _show: function() {
       var view = _.last(this._views);
-      var el = view ? view.render().el : null
+      var el = view ? view.render().el : null;
 
       $('#modal').html(el).show();
     },
@@ -45,7 +45,7 @@ define([
     _hide: function() {
       $('#modal').html('').hide();
     }
-  }
+  };
 
   return ModalManager;
 });

--- a/new_static/app/scripts/router.js
+++ b/new_static/app/scripts/router.js
@@ -17,7 +17,7 @@ define([
       },
 
       setStage: function(view) {
-        $("#stage").html(view.render().el);
+        $('#stage').html(view.render().el);
 
         view.afterInsert();
       }

--- a/new_static/app/scripts/views/base.js
+++ b/new_static/app/scripts/views/base.js
@@ -1,10 +1,12 @@
+/*global define*/
+
 define(
   [
-    "underscore",
-    "backbone"
+    'underscore',
+    'backbone'
   ],
   function(_, Backbone) {
-    "use strict";
+    'use strict';
 
     /**
     * Base class for views that provides common rendering, model presentation, DOM assignment,
@@ -95,9 +97,9 @@ define(
       * @param {Backbone.View} itemView view for rendering each item in the collection
       * @param {String} selector jQuery selector to insert the collected elements
       */
-      renderCollection: function(itemView, selector) {
+      renderCollection: function(ItemView, selector) {
         var els = this.collection.collect(function(item) {
-          return this.trackSubview(new itemView({ model: item })).render().el;
+          return this.trackSubview(new ItemView({ model: item })).render().el;
         }.bind(this));
 
         this.$(selector).append(els);
@@ -153,7 +155,7 @@ define(
       * @method destroySubviews
       */
       destroySubviews: function() {
-        _.invoke(this.subviews, "destroy");
+        _.invoke(this.subviews, 'destroy');
 
         this.subviews = [];
       }

--- a/new_static/app/scripts/views/location.js
+++ b/new_static/app/scripts/views/location.js
@@ -1,4 +1,4 @@
-/*global define*/
+/*global define,alert*/
 
 define([
   'views/base',
@@ -22,11 +22,11 @@ define([
     },
 
     lostMode: function(event) {
-      alert("LOSING THE DEVICE");
+      alert('LOSING THE DEVICE');
     },
 
     erase: function(event) {
-      alert("ERASING THE DEVICE");
+      alert('ERASING THE DEVICE');
     },
 
     afterInsert: function() {


### PR DESCRIPTION
... And turning off `indent` in .jshintrc since it is causing too much noise right now.

Current `$ grunt jshint` errors include:

```
$ grunt jshint
Running "jshint:all" (jshint) task

app/scripts/main.js
  line 30  col 30  'Router' is defined but never used.

app/scripts/views/location.js
  line 34  col 17  'L' is not defined.
  line 37  col 11  'L' is not defined.
  line 20  col 30  'event' is defined but never used.
  line 24  col 29  'event' is defined but never used.
  line 28  col 26  'event' is defined but never used.

✖ 6 problems

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.
```
