### PR TITLE
updating versions, removing ~, adding missing fields

### DIFF
--- a/new_static/package.json
+++ b/new_static/package.json
@@ -11,6 +11,12 @@
   "homepage": "https://github.com/jrconlin/wmf",
   "bugs": "https://github.com/jrconlin/wmf/issues/",
   "license": "MPL 2.0",
+  "scripts": {
+    "postinstall": "bower install",
+    "start": "grunt",
+    "test": "grunt test",
+    "contributors": "git shortlog -s | cut -c8- | sort -f > CONTRIBUTORS"
+  },
   "dependencies": {},
   "devDependencies": {
     "connect-livereload": "0.3.2",


### PR DESCRIPTION
Or if you're saying that npm-shrinkwrap will work w/ "~" dependencies, we can add those back in. I was just updating to the latest package versions of each module and setting explicit package numbers since that is how we did it in fxa-auth and fxa-content.
