### PR TITLE
[new_frontend] Organizing the main.scss Sass file and breaking it up

### DIFF
--- a/new_static/Gruntfile.js
+++ b/new_static/Gruntfile.js
@@ -287,6 +287,9 @@ module.exports = function (grunt) {
             }
         },
         sass: {                                 // Task
+            options: {
+                imagePath: '../images'
+            },
             dist: {                             // Target
                 files: {                        // Dictionary of files
                     '<%= yeoman.tmp %>/styles/main.css': '<%= yeoman.app %>/styles/main.scss'     // 'destination': 'source'

--- a/new_static/app/styles/_media_queries.scss
+++ b/new_static/app/styles/_media_queries.scss
@@ -1,0 +1,55 @@
+/* Desktop */
+
+@media only screen and (min-width: 768px) {
+  #stage {
+    footer {
+      background: $footer-background-color--desktop;
+      bottom: auto;
+      color: $footer-text-color--desktop;
+      height: 47px;
+      padding-left: 26px; // 34px - 8px for button padding
+      text-align: left;
+      top: 47px;
+
+      .button {
+        height: 47px;
+        width: auto;
+
+        a {
+          background: image-url('icon-sound.png') no-repeat left 50%;
+          display: inline-block;
+          font-size: 13px;
+          height: 47px;
+          padding: 15px 12px 0 40px;
+          text-indent: 0;
+          width: auto;
+
+          &:hover {
+            background-color: $footer-link-hover-background-color--desktop;
+          }
+        }
+
+        &.play-sound a {
+          background-image: image-url('icon-sound.png');
+        }
+
+        &.lost-mode a {
+          background-image: image-url('icon-lock.png');
+          margin: 0;
+        }
+
+        &.erase a {
+          background-image: image-url('icon-erase.png');
+        }
+      }
+    }
+  }
+
+  .leaflet-top {
+    top: 95px;
+  }
+
+  .leaflet-bottom {
+    bottom: 0;
+  }
+}

--- a/new_static/app/styles/_variables.scss
+++ b/new_static/app/styles/_variables.scss
@@ -1,0 +1,14 @@
+// FONT FAMILIES
+$default-font-family: 'TypoPRO Fira Sans', sans-serif;
+
+// COLORS
+$footer-background-color--desktop: #e7e7e7;
+$footer-background-color: #242426;
+$footer-link-active-background-color: #6f7181;
+$footer-link-background-color: #6f7181;
+$footer-link-hover-background-color--desktop: #d9d9d9;
+$footer-text-color--desktop: #333;
+$footer-text-color: #f2f1ec;
+$header-background-color: #f4f4f4;
+$heading-text-color: #8a8b97;
+$modal-background-color: #fff;

--- a/new_static/app/styles/main.scss
+++ b/new_static/app/styles/main.scss
@@ -1,13 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@import "variables";
+
 /* Border box all the things */
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: border-box;
 }
 
-html, body, input, select {
-  font-family: 'TypoPRO Fira Sans', sans-serif;
+html,
+body,
+input,
+select {
+  font-family: $default-font-family;
 }
 
-html, body, #stage, #stage > div, #map {
+html,
+body,
+#stage,
+#stage > div,
+#map {
   height: 100%;
   width: 100%;
 }
@@ -20,7 +35,7 @@ a {
   position: relative;
 
   header {
-    background: #f4f4f4;
+    background: $header-background-color;
     height: 47px;
     left: 0;
     padding: 0 34px;
@@ -30,7 +45,7 @@ a {
     z-index: 1000;
 
     h1 {
-      color: #8a8b97;
+      color: $heading-text-color;
       font-size: 27px;
       font-weight: normal;
       height: 32px;
@@ -41,9 +56,9 @@ a {
   }
 
   footer {
-    background: #242426;
-    color: #f2f1ec;
+    background: $footer-background-color;
     bottom: 0;
+    color: $footer-text-color;
     height: 39px;
     left: 0;
     position: absolute;
@@ -57,36 +72,36 @@ a {
       width: 33%;
 
       a {
-        background: url(../images/icon-sound-white.png) no-repeat 50% 50%;
+        background: image-url('icon-sound-white.png') no-repeat 50% 50%;
         display: block;
         font-size: 13px;
         height: 39px;
+        line-height: 1em;
         text-indent: -1000em;
         width: 100%;
-        line-height: 1em;
 
         &:active {
-          background-color: #6f7181;
+          background-color: $footer-link-active-background-color;
         }
       }
 
       &.play-sound a {
-        background-image: url(../images/icon-sound-white.png);
+        background-image: image-url('icon-sound-white.png');
       }
 
       &.lost-mode a {
-        background-image: url(../images/icon-lock-white.png);
+        background-image: image-url('icon-lock-white.png');
       }
 
       &.erase a {
-        background-image: url(../images/icon-erase-white.png);
+        background-image: image-url('icon-erase-white.png');
       }
     }
   }
 }
 
 #modal {
-  background: #fff;
+  background: $modal-background-color;
   display: none;
   height: 100%;
   left: 0;
@@ -104,58 +119,4 @@ a {
   bottom: 30px;
 }
 
-/* Desktop */
-
-@media only screen and (min-width: 768px) {
-  #stage {
-    footer {
-      background: #e7e7e7;
-      bottom: auto;
-      color: #333;
-      height: 47px;
-      padding-left: 26px; // 34px - 8px for button padding
-      text-align: left;
-      top: 47px;
-
-      .button {
-        height: 47px;
-        width: auto;
-
-        a {
-          background: url(../images/icon-sound.png) no-repeat left 50%;
-          display: inline-block;
-          font-size: 13px;
-          height: 47px;
-          padding: 15px 12px 0 40px;
-          text-indent: 0;
-          width: auto;
-
-          &:hover {
-            background-color: #d9d9d9;
-          }
-        }
-
-        &.play-sound a {
-          background-image: url(../images/icon-sound.png);
-        }
-
-        &.lost-mode a {
-          background-image: url(../images/icon-lock.png);
-          margin: 0;
-        }
-
-        &.erase a {
-          background-image: url(../images/icon-erase.png);
-        }
-      }
-    }
-  }
-
-  .leaflet-top {
-    top: 95px;
-  }
-
-  .leaflet-bottom {
-    bottom: 0;
-  }
-}
+@import "media_queries";

--- a/new_static/package.json
+++ b/new_static/package.json
@@ -37,7 +37,7 @@
     "grunt-open": "0.2.3",
     "grunt-requirejs": "0.4.1",
     "grunt-rev": "0.1.0",
-    "grunt-sass": "0.11.0",
+    "grunt-sass": "0.12.1",
     "grunt-usemin": "2.0.2",
     "jshint-stylish": "0.1.5",
     "load-grunt-tasks": "0.4.0",


### PR DESCRIPTION
A neat new feature in grunt-sass is the [imagePath](https://github.com/sindresorhus/grunt-sass#imagepath) which lets you set a base URL for images. So instead of doing `url(../images/icon-erase-white.png)` we can declare the `imagePath` as "../images" in the Gruntfile and then just specify the image URL as `image-url('icon-erase-white.png')` which makes it easier to relocate images or have build specific paths or whatever.

```
- background-image: url('../images/icon-erase-white.png'); // OLDNESS
+ background-image: image-url('icon-erase-white.png');     // NEWNESS
```

I also broke out all the colors and font-family into variables in _variables.scss so we can reuse colors instead of redeclaring them everywhere and ending up with a bunch of inconsistent numbers (looking at _YOU_ fxa-content-server).
