### PR TITLE
Hack to fix old, invalid hawk sigs

### DIFF
--- a/wmf/handlers.go
+++ b/wmf/handlers.go
@@ -707,6 +707,12 @@ func (self *Handler) verifyHawkHeader(req *http.Request, body []byte, devRec *st
 		return false
 	}
 
+    if self.config.GetFlag("hawk.OKBlank") && devRec.Secret == "" {
+        self.logger.Info(self.logCat, "Allowing old device",
+            util.Fields{"deviceId": devRec.ID})
+        return true
+    }
+
 	if self.config.GetFlag("hawk.disabled") {
 		return true
 	}


### PR DESCRIPTION
- iff the db has a blank secret, allow the device to continue
