### PR TITLE
Fixed missing code in lock command

### DIFF
--- a/static/app/scripts/views/lost_mode_passcode.js
+++ b/static/app/scripts/views/lost_mode_passcode.js
@@ -35,7 +35,9 @@ define([
     activate: function (event) {
       event.preventDefault();
 
-      this.device.sendCommand(new LockCommand({ code: this.passcode2, message: this.note }));
+      this.passcode1 = this.$('input.passcode-1').val();
+
+      this.device.sendCommand(new LockCommand({ code: this.passcode1, message: this.note }));
 
       this.device.set('activity', 'lost');
 


### PR DESCRIPTION
Manged to break sending the passcode to the server while "improving" validations. Should be fixed now.

@pdehaan @jrconlin r?
