### PR TITLE
feat: allow fxa issuer to be a config option

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -97,6 +97,8 @@ auth.disabled=true
 #fxa.client_secret
 # Firefox Accounts Content endpoint
 #fxa.content.endpoint=https://profile.accounts.firefox.com/v1
+# Firefox Account Issuer
+#fxa.issuer=api.accounts.firefox.com
 
 # Session Cookie Information
 # The 32 or 64 byte key to encrypt the data


### PR DESCRIPTION
since various releases could point to various fxa verifiers, specify the verifier as a config option (defaults to prod)

Also rudimentary check on emaill; must include a @.
